### PR TITLE
fix(*): prevent leaks from prior runs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var Handlebars = require('handlebars');
 
 var generate = require('./lib/generate');
 var parseComments = require('./lib/parseComments');
-var tags = require('./lib/tags');
+var defaultTags = require('./lib/tags');
 var utils = require('./lib/utils');
 
 /**
@@ -86,13 +86,7 @@ function livingcss(source, dest, options) {
   options.loadcss = (typeof options.loadcss === 'undefined' ? true : options.loadcss);
 
   // add custom tags
-  for (var tag in options.tags) {
-    if (!options.tags.hasOwnProperty(tag)) {
-      continue;
-    }
-
-    tags[tag] = options.tags[tag];
-  }
+  var tags = Object.assign({}, defaultTags, options.tags);
 
   return Promise.all([
     // read the handlebars template
@@ -166,9 +160,12 @@ function livingcss(source, dest, options) {
 
     // wait until all promises have returned (either rejected or resolved) before
     // returning the last promise
-    return Promise.all(promises);
+    return Promise.all(promises).then(function() {
+      defaultTags.resetForwardReference();
+    });
   })
   .catch(function(err) {
+    defaultTags.resetForwardReference();
 
     // in a gulp pipeline we don't want to log the error as gulp-util will do that
     // for us
@@ -183,5 +180,5 @@ function livingcss(source, dest, options) {
 module.exports = livingcss;
 module.exports.generate = generate;
 module.exports.parseComments = parseComments;
-module.exports.tags = tags;
+module.exports.tags = defaultTags;
 module.exports.utils = utils;

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -418,3 +418,8 @@ tags.code = tags.example;  // @code and @example generate the same structure
 
 module.exports = tags;
 module.exports.forwardReferenceSections = forwardReferenceSections;
+module.exports.resetForwardReference = function resetForwardReference() {
+  for (var name in forwardReferenceSections) {
+    delete forwardReferenceSections[name];
+  }
+}

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -5,6 +5,7 @@ var expect = require('chai').expect;
 var sinon = require('sinon');
 var path = require('path');
 var livingcss = require('../index');
+var tags = require('../lib/tags');
 
 describe('livingcss', function() {
 
@@ -66,6 +67,56 @@ describe('livingcss', function() {
       expect(e.message.indexOf('section \'Buttons\' is not defined')).to.not.equal(-1);
 
       done();
+    });
+  });
+
+  it('should not carry over undefined section error from previous run', function() {
+    expect(Object.keys(tags.forwardReferenceSections).length).to.equal(0);
+  });
+
+  it('should use custom tags', function(done) {
+    var file = path.join(__dirname, 'data/simple-tag.css');
+    var options = {
+      preprocess: function(context) {
+        return false;
+      },
+      tags: {
+        tagName: function() {
+          return false;
+        }
+      }
+    };
+
+    sinon.spy(options.tags, 'tagName');
+
+    livingcss(file, '.', options).then(function() {
+      expect(options.tags.tagName.called).to.be.true;
+      done();
+    })
+    .catch(function(e) {
+      done(e);
+    });
+  });
+
+  it('should not modify original tags', function(done) {
+    var file = path.join(__dirname, 'data/section.css');
+    var options = {
+      preprocess: function(context) {
+        return false;
+      },
+      tags: {
+        foo: function() {
+          return false;
+        }
+      }
+    };
+
+    livingcss(file, '.', options).then(function() {
+      expect(tags.foo).to.not.exist;
+      done();
+    })
+    .catch(function(e) {
+      done(e);
     });
   });
 


### PR DESCRIPTION
Running `livingcss` multiple times in a row caused  `tags` and `forwardReferenceSections` to carry over from run to run.